### PR TITLE
リマインダーの未設定を可能にする #52

### DIFF
--- a/DoraPresentationTimer.xcodeproj/project.pbxproj
+++ b/DoraPresentationTimer.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 2620;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					C54EC78E2916B70600CC131C = {
 						CreatedOnToolsVersion = 14.1;
@@ -155,6 +155,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -218,6 +219,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/DoraPresentationTimer/Features/Settings/AppSettings.swift
+++ b/DoraPresentationTimer/Features/Settings/AppSettings.swift
@@ -24,7 +24,7 @@ struct AppSettings: Codable, Equatable {
 struct ReminderRule: Codable, Equatable, Identifiable {
     let id: UUID
     var label: String
-    var secondsBeforeEnd: Int
+    var secondsBeforeEnd: Int?
     var sound: SoundType
     var isEnabled: Bool
 }

--- a/DoraPresentationTimer/Features/Settings/SettingsStore.swift
+++ b/DoraPresentationTimer/Features/Settings/SettingsStore.swift
@@ -36,7 +36,10 @@ final class SettingsStore: ObservableObject {
         s.reminders = s.reminders.map { r in
             var r = r
             if r.sound == .dora { r.secondsBeforeEnd = 0 }
-            r.secondsBeforeEnd = max(0, r.secondsBeforeEnd)
+            if let secondsBeforeEnd = r.secondsBeforeEnd {
+                let normalizedSeconds = max(0, secondsBeforeEnd)
+                r.secondsBeforeEnd = r.sound == .dora || normalizedSeconds > 0 ? normalizedSeconds : nil
+            }
             return r
         }
 
@@ -46,8 +49,8 @@ final class SettingsStore: ObservableObject {
         let maxSec = s.durationSeconds
         s.reminders = s.reminders.map { r in
             var r = r
-            if r.sound != .dora {
-                r.secondsBeforeEnd = min(r.secondsBeforeEnd, maxSec)
+            if r.sound != .dora, let secondsBeforeEnd = r.secondsBeforeEnd {
+                r.secondsBeforeEnd = min(secondsBeforeEnd, maxSec)
             }
             return r
         }

--- a/DoraPresentationTimer/Features/Settings/SettingsView.swift
+++ b/DoraPresentationTimer/Features/Settings/SettingsView.swift
@@ -19,8 +19,6 @@ private enum EditTarget: Identifiable {
     }
 }
 
-import SwiftUI
-
 struct SettingsView: View {
     @EnvironmentObject var settingsStore: SettingsStore
     @State private var editTarget: EditTarget?
@@ -41,7 +39,7 @@ struct SettingsView: View {
             
             Section("Reminders") {
                 ForEach(settingsStore.settings.reminders) { r in
-                    let middleText = (r.sound == .dora) ? "" : "終了\(r.secondsBeforeEnd)秒前"
+                    let middleText = reminderText(for: r)
                     
                     oneLineRow(
                         left: r.label,
@@ -75,11 +73,11 @@ struct SettingsView: View {
 
             case .reminder(let id):
                 if let rule = settingsStore.settings.reminders.first(where: { $0.id == id }) {
-                    TimePickerSheet(
+                    ReminderTimePickerSheet(
                         title: rule.label,
                         totalSeconds: Binding(
                             get: {
-                                settingsStore.settings.reminders.first(where: { $0.id == id })?.secondsBeforeEnd ?? 0
+                                settingsStore.settings.reminders.first(where: { $0.id == id })?.secondsBeforeEnd
                             },
                             set: { newValue in
                                 settingsStore.update { settings in
@@ -88,13 +86,19 @@ struct SettingsView: View {
                                 }
                             }
                         ),
-                        isTimerRunning: false
+                        maxSeconds: settingsStore.settings.durationSeconds
                     )
                     .presentationDetents([.fraction(0.35), .medium])
                     .presentationDragIndicator(.visible)
                 }
             }
         }
+    }
+
+    private func reminderText(for rule: ReminderRule) -> String {
+        guard rule.sound != .dora else { return "" }
+        guard let secondsBeforeEnd = rule.secondsBeforeEnd else { return "未設定" }
+        return "終了\(secondsBeforeEnd)秒前"
     }
     
     private func oneLineRow(

--- a/DoraPresentationTimer/Features/Timer/TimePickerSheet.swift
+++ b/DoraPresentationTimer/Features/Timer/TimePickerSheet.swift
@@ -17,6 +17,16 @@ struct TimePickerSheet: View {
     @State private var minute: Int = 0
     @State private var second: Int = 0
 
+    init(
+        title: String,
+        totalSeconds: Binding<Int>,
+        isTimerRunning: Bool
+    ) {
+        self.title = title
+        self._totalSeconds = totalSeconds
+        self.isTimerRunning = isTimerRunning
+    }
+
     var body: some View {
         NavigationStack {
             HStack(spacing: 24) {
@@ -50,6 +60,117 @@ struct TimePickerSheet: View {
             Text(title).foregroundStyle(.secondary)
             Picker(selection: value, label: EmptyView()) {
                 ForEach(0..<60, id: \.self) { Text("\($0)") }
+            }
+            .pickerStyle(.wheel)
+            .clipped()
+        }
+    }
+}
+
+struct ReminderTimePickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let title: String
+    @Binding var totalSeconds: Int?
+    let maxSeconds: Int
+
+    @State private var minute: Int?
+    @State private var second: Int?
+
+    private var normalizedMaxSeconds: Int {
+        max(0, maxSeconds)
+    }
+
+    private var maxMinute: Int {
+        normalizedMaxSeconds / 60
+    }
+
+    private var maxSecondForSelectedMinute: Int {
+        guard let minute else {
+            return min(59, normalizedMaxSeconds)
+        }
+
+        return minute == maxMinute ? normalizedMaxSeconds % 60 : 59
+    }
+
+    private var minuteValues: [Int] {
+        guard maxMinute > 0 else { return [] }
+        return Array(0...maxMinute)
+    }
+
+    private var secondValues: [Int] {
+        guard maxSecondForSelectedMinute > 0 else { return [] }
+        return Array(0...maxSecondForSelectedMinute)
+    }
+
+    var body: some View {
+        NavigationStack {
+            HStack(spacing: 24) {
+                labeledPicker(title: "分", value: $minute, values: minuteValues)
+                labeledPicker(title: "秒", value: $second, values: secondValues)
+            }
+            .padding()
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .onAppear {
+            applyInitialValue()
+        }
+        .onChange(of: minute) { sync() }
+        .onChange(of: second) { sync() }
+    }
+
+    private func applyInitialValue() {
+        guard let totalSeconds, totalSeconds > 0 else {
+            minute = nil
+            second = nil
+            return
+        }
+
+        let clamped = min(totalSeconds, normalizedMaxSeconds)
+        guard clamped > 0 else {
+            minute = nil
+            second = nil
+            self.totalSeconds = nil
+            return
+        }
+
+        let initialMinute = clamped / 60
+        let initialSecond = clamped % 60
+        minute = initialMinute == 0 ? nil : initialMinute
+        second = initialSecond == 0 ? nil : initialSecond
+        self.totalSeconds = clamped
+    }
+
+    private func sync() {
+        guard minute != nil || second != nil else {
+            totalSeconds = nil
+            return
+        }
+
+        let clampedSecond: Int?
+        if let second, second > maxSecondForSelectedMinute {
+            clampedSecond = maxSecondForSelectedMinute > 0 ? maxSecondForSelectedMinute : nil
+            self.second = clampedSecond
+        } else {
+            clampedSecond = second
+        }
+
+        let total = min(max(0, (minute ?? 0) * 60 + (clampedSecond ?? 0)), normalizedMaxSeconds)
+        totalSeconds = total == 0 ? nil : total
+    }
+
+    private func labeledPicker(title: String, value: Binding<Int?>, values: [Int]) -> some View {
+        VStack(spacing: 8) {
+            Text(title).foregroundStyle(.secondary)
+            Picker(selection: value, label: EmptyView()) {
+                Text(" ").tag(Int?.none)
+                ForEach(values, id: \.self) { Text("\($0)").tag(Optional($0)) }
             }
             .pickerStyle(.wheel)
             .clipped()

--- a/DoraPresentationTimer/Features/Timer/TimerRules.swift
+++ b/DoraPresentationTimer/Features/Timer/TimerRules.swift
@@ -26,23 +26,23 @@ struct TimerRules {
         guard remainingSeconds >= 0 else { return nil }
         guard durationSeconds >= 0 else { return nil }
         
-        // 有効なルールのみ
-        let enabledReminders = reminders.filter { $0.isEnabled }
+        // 有効で時刻が設定されているルールのみ
+        let enabledReminders = reminders.filter { $0.isEnabled && $0.secondsBeforeEnd != nil }
 
         // 「残り◯秒」で鳴るルールを探す
         guard let rule = enabledReminders.first(where: {
             $0.secondsBeforeEnd == remainingSeconds
-        }) else {
+        }), let secondsBeforeEnd = rule.secondsBeforeEnd else {
             return nil
         }
 
         // 初期時間以下のリマインドは鳴らさない
-        if durationSeconds <= rule.secondsBeforeEnd {
+        if durationSeconds <= secondsBeforeEnd {
             return nil
         }
 
         // 終了（リマインドが終了時間より後に設定されていても無視））
-        if rule.secondsBeforeEnd == 0 {
+        if secondsBeforeEnd == 0 {
             return .finished
         }
 

--- a/DoraPresentationTimer/Features/Timer/TimerView.swift
+++ b/DoraPresentationTimer/Features/Timer/TimerView.swift
@@ -59,8 +59,17 @@ struct TimerView: View {
             }
         }
         .onAppear {
-            viewModel.setInitialTime(minutes: selectedMinute, seconds: selectedSecond)
+            syncSelectedTimeFromViewModel()
         }
+    }
+    
+    /// TimePickerSheet の初期表示を、現在の残り時間に合わせる
+    ///
+    /// viewModel の値は変更せず、Picker用の selectedMinute / selectedSecond のみ更新する。
+    private func syncSelectedTimeFromViewModel() {
+        let total = max(0, viewModel.remainingSeconds)
+        selectedMinute = total / 60
+        selectedSecond = total % 60
     }
 }
 
@@ -68,6 +77,8 @@ private extension TimerView {
     private func timeSection() -> some View {
         Button {
             guard !viewModel.isTimerRunning else { return }
+            
+            syncSelectedTimeFromViewModel()
             isPickerPresented = true
         } label: {
             GeometryReader { geo in


### PR DESCRIPTION
## 概要
• リマインド1回目・2回目の時間を nil 許容に変更
• リマインド時間を未設定にできるように対応
• リマインド用ホイールの最大値を発表時間に合わせて制限

## 変更内容
• ReminderRule.secondsBeforeEnd を Int から Int? に変更
• nil のリマインドは「未設定」と表示
• リマインド用に ReminderTimePickerSheet を追加
• 分・秒ホイールの選択肢を 空欄, 1, 2, 3... に変更
• 分も秒も空欄の場合は nil として保存
• 片方だけ空欄の場合は、その単位を 0 として秒数を計算
• 通常リマインドで 0秒前 になった場合は nil に正規化
• 終了時間の .dora はこれまで通り 0秒前 固定
• nil のリマインドはタイマー発火判定から除外

## 動作確認内容
• Settings 画面を開き、リマインド1回目をタップする
• 分・秒ホイールに空欄が表示されることを確認する
• 分・秒を両方空欄にして閉じる
• リマインド1回目が「未設定」と表示されることを確認する
• リマインド2回目でも同じ操作ができることを確認する
• 分だけ選択、秒を空欄にした場合に、正しい秒数として表示されることを確認する
• 分を空欄、秒だけ選択した場合に、正しい秒数として表示されることを確認する
• 発表時間を短くしたあと、リマインドのホイール最大値が発表時間を超えないことを確認する
• 分・秒を両方空欄にしたリマインドが、タイマー実行中に鳴らないことを確認する
• 終了時間の音はこれまで通りタイマー終了時に鳴ることを確認する